### PR TITLE
Use xcopy instead of copy, f for File, /s to create dirs, overwrite using /y

### DIFF
--- a/imx6-Bluetooth/imx6-Bluetooth.vcxproj
+++ b/imx6-Bluetooth/imx6-Bluetooth.vcxproj
@@ -81,7 +81,7 @@
       <AdditionalOptions>-march=armv7-a -mthumb -mfpu=neon -mfloat-abi=hard --sysroot=/usr/local/oecore-x86_64/sysroots/armv7at2hf-neon-angstrom-linux-gnueabi %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(ProjectDir)bin\$(Platform)\$(Configuration)\$(ProjectName).out" "$(ProjectDir)bin\ARM\$(Configuration)\$(ProjectName).out"</Command>
+      <Command>echo f | xcopy /s/y "$(ProjectDir)bin\$(Platform)\$(Configuration)\$(ProjectName).out" "$(ProjectDir)bin\ARM\$(Configuration)\$(ProjectName).out"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
Hi Mark!

Thanks for providing an example, it really helped me get started on getting VS17 as frontend for my remote debugging!

This PR will fix a issue where it will not copy the Out file to the ARM bin, if the directories did not exist before. It will also overwriting existing Out file. 
