### PR TITLE
Use as many USER_MACROS as possible in IncludeDirs. Users still need …

### DIFF
--- a/imx6-Bluetooth/imx6-Bluetooth.vcxproj
+++ b/imx6-Bluetooth/imx6-Bluetooth.vcxproj
@@ -71,7 +71,7 @@
     <RemoteLinkLocalCopyOutput>false</RemoteLinkLocalCopyOutput>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
-    <IncludePath>C:\Users\mgoodner\AppData\Local\Microsoft\Linux\Header Cache\1.0\-50327719\usr\local\oecore-x86_64\sysroots\armv7at2hf-neon-angstrom-linux-gnueabi\usr\include</IncludePath>
+    <IncludePath>$(LOCALAPPDATA)\Microsoft\$(ApplicationType)\Header Cache\$(ApplicationTypeRevision)\-50327719\usr\local\oecore-x86_64\sysroots\armv7at2hf-neon-angstrom-linux-gnueabi\usr\include</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>


### PR DESCRIPTION
Hi Mark!

Thanks for providing this example!

This PR will update IncludeDirs for the ARM project. The user still needs to update the path to reflect their own Include Dirs (\usr\local\oecore-x86_64\sysroots\armv7at2hf-neon-angstrom-linux-gnueabi\usr\include) but this will at least give an indication on what to change.

It is not clear on how to obtain the cache dir -50327719, I hope there will be a MACRO for this in the future. 

Perhaps a better solution for this IncludeDir is to set useCompiler to false and specify the remote include dirs, 

```
  <useCompiler>false</useCompiler>
  <!--the directories that are downloaded to the local system-->
  <includeDirs><![CDATA[/usr/local/oecore-x86_64/sysroots/armv7at2hf-neon-angstrom-linux-gnueabi/usr/include;]]></includeDirs>

```
with the drawback that no preprocessor defines are extracted.

Using VS17 15.9.2, the Header Cache dir will not get populated with remote headers if the Settings.xml does not change rsync_ssh to sftp_ssh. This will have VS17 to Zip the remote headers and unzip them in the local header cache.
